### PR TITLE
Downgrade the required PHP version to 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": ">=7.3.2",
+    "php": ">=7.2",
     "moxie-lean/loader": "^1.3"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,53 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0863662a5ebdba70b430cfb220ca0f5",
-    "packages": [],
+    "content-hash": "9c9c547a2d1439b1d0b83f19ec39dcc1",
+    "packages": [
+        {
+            "name": "moxie-lean/loader",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://bitbucket.org/leanlegacy/loader.git",
+                "reference": "3ada92d475cc1e10d07e4be443a6d37a56b78aae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://bitbucket.org/leanlegacy/loader/get/3ada92d475cc1e10d07e4be443a6d37a56b78aae.zip",
+                "reference": "3ada92d475cc1e10d07e4be443a6d37a56b78aae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "squizlabs/php_codesniffer": "2.*",
+                "wp-coding-standards/wpcs": "0.9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lean\\": "src/"
+                },
+                "files": [
+                    "./src/config.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Crisoforo Gaspar",
+                    "email": "github@crisoforo.com"
+                }
+            ],
+            "description": "Loader for files in wordpress making things easier instead of using a require",
+            "homepage": "https://bitbucket.org/leanlegacy/loader",
+            "time": "2017-07-24T15:05:44+00:00"
+        }
+    ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
@@ -13,7 +58,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3.2"
+        "php": ">=7.2"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
Downgrade the required PHP version to 7.2 to make it compatible with the composer requirements for CI on Pantheon.